### PR TITLE
[APP-2773] Add utils pulled from dr_components

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,2 @@
+from .markdown_helpers import remove_markdown_space, remove_main_container_padding, get_markdown_span_selector
+from .move_st_sidebar import move_st_sidebar_right

--- a/utils/markdown_helpers.py
+++ b/utils/markdown_helpers.py
@@ -1,0 +1,69 @@
+import streamlit as st
+
+
+def get_markdown_span_selector(key):
+    """Helper to identify a specific markdown span element by the given key.
+        Intended to be used together with ':has( > ...)' to find element-containers
+    Parameters
+    ----------
+    key: str or None
+        Key that uniquely identifies the custom component
+        Note that providing 'None' will target ALL custom markdown spans in the app
+    Returns
+    -------
+    str
+        CSS Selector for the custom span markdown of the given key
+    """
+    class_str = f".{key}" if key is not None or "" else ""
+
+    return f"""
+            div.stMarkdown > div[data-testid="stMarkdownContainer"] > p > span{class_str}
+        """
+
+
+def remove_markdown_space():
+    """Remove default gaps and margins around st.markdown components. Note: Run it at the top of your app."""
+
+    # TODO: Once basic stylesheet is added, check if this style can move there. See ISSUE APP-2788
+
+    st.markdown(
+        f"""
+        <style class="hidden">
+            /*
+            * Streamlit adds margins and heights to every st.markdown element, even if it doesnt contain any visible
+            * elements. Hide all elements that contain a script or style tag with the 'hidden' class.
+            */
+            div[data-testid="element-container"]:has(> div.stMarkdown > div[data-testid="stMarkdownContainer"]
+              > style.hidden),
+              div[data-testid="element-container"]:has(> div.stMarkdown > div[data-testid="stMarkdownContainer"]
+              > script.hidden) {{
+                display: none;
+            }}
+            
+            /* Hide the spans that help CSS selectors to find the right sibling elements. Uses class 'hidden'  */
+            .element-container:has(> {get_markdown_span_selector('hidden')}) {{ 
+                display: none;
+            }}
+        </style>
+    """,
+        unsafe_allow_html=True,
+    )
+
+
+def remove_main_container_padding():
+    """Removes the empty space around main section and the large padding around block-container element.
+    Note: Run it at the top of your app."""
+
+    # TODO: Once basic stylesheet is added, check if this style can move there. See ISSUE APP-2788
+
+    st.markdown(
+        """
+            <style class="hidden">
+                .block-container {
+                    padding: 4rem 1rem 0rem;
+                    min-height: 80%;
+                }
+            </style>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/utils/move_st_sidebar.py
+++ b/utils/move_st_sidebar.py
@@ -1,0 +1,62 @@
+import streamlit as st
+
+def move_st_sidebar_right():
+    """Helper to flip the Streamlit sidebar to the right side of the view. Note: Run it at the top of your app.
+    Parameters
+    ----------
+    Returns
+    -------
+    """
+
+    # TODO: Once basic stylesheet is added, check if this style can move there. See ISSUE APP-2788
+
+    if 'moved_st_sidebar_right' not in st.session_state:
+        st.session_state['moved_st_sidebar_right'] = True
+
+    style_text = f"""
+        <style class='hidden'>
+            header[data-testid="stHeader"] {{
+                z-index: 991;
+            }}
+            
+            div[data-testid="collapsedControl"] {{
+                top: 3rem;
+                right: 0.25rem;
+                left: auto;
+                height: 100%;
+                z-index: 990;
+            }}
+            
+            div[data-testid="collapsedControl"] > button {{
+                transform: scaleX(-1)
+            }}
+            
+            div.appview-container section[data-testid="stSidebar"]:first-child {{
+                top: 3rem;
+                order: 2;
+                transform: none;
+                transition: transform 300ms ease 0s, min-width 300ms ease 0s, max-width 300ms ease 0s;
+                z-index: 990;
+            }}
+
+            div.appview-container section[data-testid="stSidebar"]:nth-child(2) {{
+                top: 3rem;
+                order: 2;
+                transform: translateX(+336px);
+                transition: transform 300ms ease 0s, min-width 300ms ease 0s, max-width 300ms ease 0s;
+                z-index: 990;
+            }}
+            
+            @media only screen and (max-width: 767px) {{
+              div.appview-container {{
+                    place-content: flex-end;
+                }}
+            }}
+
+            div.appview-container div[data-testid="stSidebarContent"] + div > div {{
+                /*Hides the sidebar resize handle, it cannot function properly when flipped to the right*/
+                display: none;
+            }}
+        </style>
+    """
+    st.markdown(style_text, unsafe_allow_html=True)


### PR DESCRIPTION
## Rationale
Add useful utils from DR custom component lib

Related task: APP-2788: Move/refactor util styles into stylesheet if possible

### Summary of Changes
These utils are pulled over and slightly simplified to avoid custom component usage (theme detection)
- remove_main_container_padding
- remove_markdown_space
- get_markdown_span_selector (hopefully will get replaced by less mixins)
- move_st_sidebar_right
