### PR TITLE
[APP-2823] Change LESS TO SASS, refactor config file names

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -339,6 +339,21 @@ importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""
 referencing = ">=0.31.0"
 
 [[package]]
+name = "libsass"
+version = "0.23.0"
+description = "Sass for Python: A straightforward binding of libsass for Python."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "libsass-0.23.0-cp38-abi3-macosx_11_0_x86_64.whl", hash = "sha256:34cae047cbbfc4ffa832a61cbb110f3c95f5471c6170c842d3fed161e40814dc"},
+    {file = "libsass-0.23.0-cp38-abi3-macosx_14_0_arm64.whl", hash = "sha256:ea97d1b45cdc2fc3590cb9d7b60f1d8915d3ce17a98c1f2d4dd47ee0d9c68ce6"},
+    {file = "libsass-0.23.0-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4a218406d605f325d234e4678bd57126a66a88841cb95bee2caeafdc6f138306"},
+    {file = "libsass-0.23.0-cp38-abi3-win32.whl", hash = "sha256:31e86d92a5c7a551df844b72d83fc2b5e50abc6fbbb31e296f7bebd6489ed1b4"},
+    {file = "libsass-0.23.0-cp38-abi3-win_amd64.whl", hash = "sha256:a2ec85d819f353cbe807432d7275d653710d12b08ec7ef61c124a580a8352f3c"},
+    {file = "libsass-0.23.0.tar.gz", hash = "sha256:6f209955ede26684e76912caf329f4ccb57e4a043fd77fe0e7348dd9574f1880"},
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -1208,4 +1223,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "!=3.9.7,>=3.8"
-content-hash = "0cd202bb22b462d0096fb562d5d3f7d5f8e9ade802425a17371700b7de99d1c1"
+content-hash = "553df20fffe977985747de7ff6d0343baf7caa48b42f8dff534d884a0b636c06"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "streamlit-sal"
 version = "0.0.1"
-description = "Style and layout for your Streamlit app using LESS"
+description = "Style and layout for your Streamlit app using SASS"
 authors = ["DataRobot Developers <apps-devs@datarobot.com>"]
 license = "MIT"
 readme = "README.md"
@@ -17,6 +17,7 @@ streamlit-sal = "streamlit_sal.scripts.cli:cli"
 python = "!=3.9.7,>=3.8"
 streamlit = "1.35.0"
 click = "^8.1.7"
+libsass = "^0.23.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"

--- a/streamlit_sal/sal_config.py
+++ b/streamlit_sal/sal_config.py
@@ -1,16 +1,22 @@
 from enum import Enum
 
-BASE_STYLESHEET_FILE_NAME = 'base-stylesheet.less'
-DEFAULT_LESS_FILE_NAME = 'sal-stylesheet.less'
-DEFAULT_CSS_FILE_NAME = 'sal-stylesheet.css'
-DEFAULT_CURRENT_DIR = '.'
+# Stylesheet files (input/output)
+STYLE_DEFAULT_DIST_DIRECTORY = '.'
+
+STYLE_SASS_MAIN_FILE_NAME = 'main.scss'
+STYLE_SASS_LAYOUT_FILE_NAME = '_layout.scss'
+STYLE_SASS_UTILITIES_FILE_NAME = '_utilities.scss'
+STYLE_SASS_SOURCE_FILES = [STYLE_SASS_MAIN_FILE_NAME, STYLE_SASS_LAYOUT_FILE_NAME, STYLE_SASS_UTILITIES_FILE_NAME]
+
+STYLE_DEFAULT_CSS_FILE_NAME = 'sal-stylesheet.css'
+
+# Config util
 CONFIG_FILE_NAME = '.streamlit_sal'
 CONFIG_DEFAULT_SECTION = 'settings'
 
 
 class ConfigOptions(Enum):
-    LESS_FILE_PATH = 'less_file_path'
-    LESS_FILE_NAME = 'less_file_name'
-    CSS_FILE_PATH = 'css_file_path'
-    CSS_FILE_NAME = 'css_file_name'
+    SASS_SOURCE_PATH = 'sass_source_path'
+    CSS_STYLESHEET_FILE_PATH = 'css_stylesheet_file_path'
+    CSS_STYLESHEET_FILE_NAME = 'css_stylesheet_file_name'
 

--- a/streamlit_sal/scripts/cli.py
+++ b/streamlit_sal/scripts/cli.py
@@ -1,5 +1,5 @@
 import click
-from click import Abort, ClickException
+from click import ClickException
 
 from ..utils import run_compile
 from .init_files import run_init

--- a/streamlit_sal/scripts/init_files.py
+++ b/streamlit_sal/scripts/init_files.py
@@ -4,68 +4,58 @@ from importlib.resources import files
 
 import click
 
-from .. import CONFIG_FILE_NAME, BASE_STYLESHEET_FILE_NAME, DEFAULT_LESS_FILE_NAME, DEFAULT_CSS_FILE_NAME, \
-    DEFAULT_CURRENT_DIR, ConfigOptions
+from .. import CONFIG_FILE_NAME, STYLE_SASS_SOURCE_FILES, STYLE_DEFAULT_CSS_FILE_NAME, \
+    STYLE_DEFAULT_DIST_DIRECTORY, ConfigOptions
 from ..utils import update_config, get_config_value
 
-LESS_PATH_MSG = "Enter a path for the LESS file."
-LESS_FILE_MSG = f"Enter a name for the LESS file."
-CSS_PATH_MSG = "Enter a path for the CSS file."
-CSS_FILE_MSG = f"Enter a name for the CSS file."
+SASS_PATH_MSG = "Enter a destination path for the SASS source files"
+CSS_PATH_MSG = f"Enter a destination path for the compiled CSS file output"
+CSS_FILE_MSG = f"Enter a file name for the compiled CSS"
 
 
-def check_extension_factory(extension):
-    def check_extension(file_name):
-        if file_name and extension not in file_name:
-            return f"{file_name}{extension}"
-        else:
-            return file_name
-
-    return check_extension
+def check_css_extension(file_name):
+    if file_name and '.css' not in file_name:
+        return f"{file_name}.css"
+    else:
+        return file_name
 
 
 def run_init():
     root_dir = os.getcwd()
 
-    less_path = click.prompt(text=LESS_PATH_MSG, default=DEFAULT_CURRENT_DIR,
-                             type=click.Path(exists=False, file_okay=False))
-    less_file_name = click.prompt(text=LESS_FILE_MSG, default=DEFAULT_LESS_FILE_NAME,
-                                  value_proc=check_extension_factory('.less'),
-                                  type=click.STRING)
+    sass_src_path = click.prompt(text=SASS_PATH_MSG, default=STYLE_DEFAULT_DIST_DIRECTORY,
+                                 type=click.Path(exists=False, file_okay=False))
 
-    css_path = click.prompt(text=CSS_PATH_MSG, default=DEFAULT_CURRENT_DIR,
-                            type=click.Path(exists=False, file_okay=False))
-    css_file_name = click.prompt(text=CSS_FILE_MSG, default=DEFAULT_CSS_FILE_NAME,
-                                 value_proc=check_extension_factory('.css'),
-                                 type=click.STRING)
+    path_default = sass_src_path if sass_src_path else STYLE_DEFAULT_DIST_DIRECTORY
+    css_stylesheet_path = click.prompt(text=CSS_PATH_MSG, default=path_default,
+                                       type=click.Path(exists=False, file_okay=False))
+    css_stylesheet_file_name = click.prompt(text=CSS_FILE_MSG, default=STYLE_DEFAULT_CSS_FILE_NAME,
+                                            value_proc=check_css_extension,
+                                            type=click.STRING)
 
-    init_files(root_dir, less_path, less_file_name, css_path, css_file_name)
+    init_files(root_dir, sass_src_path, css_stylesheet_path, css_stylesheet_file_name)
 
 
-def init_files(root_dir, less_path=None, less_file_name=None, css_path=None, css_file_name=None):
+def init_files(root_dir, sass_src_path=None, css_stylesheet_path=None, css_stylesheet_file_name=None):
     if not os.path.exists(CONFIG_FILE_NAME):
         copy_template_file(CONFIG_FILE_NAME, root_dir)
 
-    if less_path:
-        update_config(ConfigOptions.LESS_FILE_PATH.value, less_path)
+    if sass_src_path:
+        update_config(ConfigOptions.SASS_SOURCE_PATH.value, sass_src_path)
 
-    if less_file_name:
-        update_config(ConfigOptions.LESS_FILE_NAME.value, less_file_name)
+    if css_stylesheet_path:
+        update_config(ConfigOptions.CSS_STYLESHEET_FILE_PATH.value, css_stylesheet_path)
 
-    if css_path:
-        update_config(ConfigOptions.CSS_FILE_PATH.value, css_path)
+    if css_stylesheet_file_name:
+        update_config(ConfigOptions.CSS_STYLESHEET_FILE_NAME.value, css_stylesheet_file_name)
 
-    if css_file_name:
-        update_config(ConfigOptions.CSS_FILE_NAME.value, css_file_name)
+    sass_source_path = get_config_value(ConfigOptions.SASS_SOURCE_PATH.value)
+    if sass_source_path != root_dir:
+        create_directory_if_not_exists(sass_source_path)
 
-    less_destination_path = get_config_value(ConfigOptions.LESS_FILE_PATH.value)
-    if less_destination_path != root_dir:
-        create_directory_if_not_exists(less_destination_path)
-
-    # Use a full path including filename to rename in case of custom name
-    less_destination_path = os.path.join(less_destination_path,
-                                         less_file_name if less_file_name else DEFAULT_LESS_FILE_NAME)
-    copy_template_file(BASE_STYLESHEET_FILE_NAME, less_destination_path)
+    # Copy all sass files to the given or default source path
+    for sass_src_file_name in STYLE_SASS_SOURCE_FILES:
+        copy_template_file(sass_src_file_name, sass_source_path)
 
 
 def copy_template_file(file_name, destination_path):

--- a/streamlit_sal/templates/.streamlit_sal
+++ b/streamlit_sal/templates/.streamlit_sal
@@ -1,5 +1,4 @@
 [settings]
-less_file_path = .
-less_file_name = sal-stylesheet.less
-css_file_path = .
-css_file_name = sal-stylesheet.css
+sass_source_path = .
+css_stylesheet_file_path = .
+css_stylesheet_file_name = sal-stylesheet.css

--- a/streamlit_sal/templates/_layout.scss
+++ b/streamlit_sal/templates/_layout.scss
@@ -1,12 +1,4 @@
-/* Base test example selector. TODO: Simplify using selector mixins APP-2777  */
-div.element-container:has(> div.stMarkdown > div[data-testid="stMarkdownContainer"] > p > span.sal-button) + div button {
-  border-radius: 5px;
-  border-color: pink;
-  color: pink;
-}
-
-/*
-* The following section contains styling for prebuilt app layouts and utils
+/* This file contains styling for prebuilt app layouts
 * Use them via the arguments given to `with sal_stylesheet`
 * reduce_markdown_spacing [Defaults to True]
 * move_sidebar_right  [Defaults to False]

--- a/streamlit_sal/templates/_utilities.scss
+++ b/streamlit_sal/templates/_utilities.scss
@@ -1,0 +1,3 @@
+/* This file contains utilities to simplify creating selectors for the Streamlit components.
+* # TODO: These utils will come with task APP-2777
+*/

--- a/streamlit_sal/templates/main.scss
+++ b/streamlit_sal/templates/main.scss
@@ -1,0 +1,14 @@
+@import 'utilities';
+@import 'layout';
+
+/* In this file you can add custom styling for your Streamlit app.
+* Either use the general style placeholders such as `%sal-button` or
+* create new style blocks using the selector utilities TODO these are coming with APP-2777
+*/
+
+/* Base test example selector. TODO: Simplify using selector mixins APP-2777  */
+div.element-container:has(> div.stMarkdown > div[data-testid="stMarkdownContainer"] > p > span.sal-button) + div button {
+  border-radius: 5px;
+  border-color: pink;
+  color: pink;
+}

--- a/streamlit_sal/utils/compile.py
+++ b/streamlit_sal/utils/compile.py
@@ -1,30 +1,20 @@
 import os
-import subprocess
-from .. import ConfigOptions
+import sass
+from .. import ConfigOptions, STYLE_SASS_MAIN_FILE_NAME
 from .config import get_config_value
 
 
 def run_compile():
-    # Define the input LESS file
-    less_path = get_config_value(ConfigOptions.LESS_FILE_PATH.value)
-    less_file = get_config_value(ConfigOptions.LESS_FILE_NAME.value)
-    input_file = os.path.join(less_path, less_file)
+    # Define the input SASS file
+    sass_path = get_config_value(ConfigOptions.SASS_SOURCE_PATH.value)
+    input_file = os.path.join(sass_path, STYLE_SASS_MAIN_FILE_NAME)
 
     # Define the output CSS file
-    css_path = get_config_value(ConfigOptions.CSS_FILE_PATH.value)
-    css_file = get_config_value(ConfigOptions.CSS_FILE_NAME.value)
+    css_path = get_config_value(ConfigOptions.CSS_STYLESHEET_FILE_PATH.value)
+    css_file = get_config_value(ConfigOptions.CSS_STYLESHEET_FILE_NAME.value)
     output_file = os.path.join(css_path, css_file)
 
-    # Define the lessc command
-    lessc_command = [
-        'lessc',
-        input_file,
-        output_file
-    ]
-
-    # Run the lessc command
-    try:
-        subprocess.run(lessc_command, check=True)
-        print(f"Compiled {input_file} to {output_file} successfully.")
-    except subprocess.CalledProcessError as e:
-        print(f"Error compiling {input_file}: {e}")
+    with open(output_file, 'w') as f:
+        compiled_css = sass.compile(filename=input_file)
+        f.write(compiled_css)
+        print(f"Compiled {input_file} to {output_file}")

--- a/streamlit_sal/utils/config.py
+++ b/streamlit_sal/utils/config.py
@@ -52,7 +52,7 @@ def find_config_file():
 
 def get_css_filepath():
     root_dir = find_root_dir()
-    path = get_config_value(ConfigOptions.CSS_FILE_PATH.value)
-    name = get_config_value(ConfigOptions.CSS_FILE_NAME.value)
+    path = get_config_value(ConfigOptions.CSS_STYLESHEET_FILE_PATH.value)
+    name = get_config_value(ConfigOptions.CSS_STYLESHEET_FILE_NAME.value)
     css_file_path = os.path.join(root_dir, path, name)
     return css_file_path


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

LESS turned out to be a problem with the lesscpy compiler. It was out of date and could not compile the required :has( >  ...) pseudo selectors.
Decision was made to switch to SASS/SCSS using libsass python compiler

### Summary of Changes

- Change compiler to libsass
- Refactor config and constant names for sass files
- Change init step to sass source file dest instead of individual file
- Split predefined layout/utils out of main file (those are not to be edited by users!)


CLI demo:

https://github.com/datarobot/streamlit-sal/assets/5627401/dd4b942f-04c3-4510-b764-f915dec2f502

