### PR TITLE
[APP-2868] Add support for header/main content style placeholder

### DIFF
--- a/streamlit_sal/templates/_style-builder.scss
+++ b/streamlit_sal/templates/_style-builder.scss
@@ -58,3 +58,11 @@ img[data-testid="stLogo"] {
 div[data-testid="stToast"] {
   @extend %sal-toast !optional;
 }
+
+div.stApp > header {
+  @extend %streamlit-app-header !optional;
+}
+
+section.main > div.block-container {
+  @extend %streamlit-app-view-block !optional;
+}


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

- Let users style header or main block themselves with predefined placeholder

### Summary of Changes

- Add new placeholders `streamlit-app-header` and `streamlit-app-view-block`