### PR TITLE
[APP-2843] Add theme support by extracting config.toml values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "streamlit-sal"
-version = "0.1.2"
+version = "0.1.3"
 description = "Style and layout for your Streamlit app using SASS"
 authors = ["DataRobot Developers <dev@datarobot.com>"]
 license = "MIT"

--- a/streamlit_sal/utils/compile.py
+++ b/streamlit_sal/utils/compile.py
@@ -2,6 +2,7 @@ import os
 from importlib.resources import files
 
 import sass
+import streamlit as st
 
 from .config import get_config_value
 from .. import ConfigOptions, STYLE_SASS_MAIN_FILE_NAME
@@ -21,5 +22,39 @@ def run_compile():
     with open(output_file, 'w') as f:
         compiled_css = sass.compile(filename=input_file,
                                     include_paths=include_paths)  # TODO Consider using output_style='compressed' ?
-        f.write(compiled_css)
+        variables_css = generate_st_theme_variables_css()
+        f.write(variables_css + '\n' + compiled_css)
         print(f"Compiled {input_file} to {output_file}")
+
+
+def generate_st_theme_variables_css():
+    primary_color = st.get_option('theme.primaryColor')
+    background_color = st.get_option('theme.backgroundColor')
+    secondary_background_color = st.get_option('theme.secondaryBackgroundColor')
+    text_color = st.get_option('theme.textColor')
+    font = st.get_option('theme.font')
+    base = st.get_option('theme.base')
+
+    css_vars = [
+        f'--st-primary-color: {primary_color};' if primary_color is not None else '',
+        f'--st-background-color: {background_color};' if background_color is not None else '',
+        f'--st-secondary-background-color: {secondary_background_color};' if secondary_background_color is not None else '',
+        f'--st-text-color: {text_color};' if text_color is not None else '',
+        f'--st-font: {font};' if font is not None else '',
+        f'--st-theme-base: {base};' if base is not None else ''
+    ]
+
+    # Ignore any empty string vars
+    css_vars_no_empty_str = [var for var in css_vars if var]
+
+    if len(css_vars_no_empty_str) > 0:
+        # Join the variables with a newline character
+        css_vars_str = "\n  ".join(css_vars_no_empty_str)
+
+        return (
+            ":root {\n"
+            f"  {css_vars_str}\n"
+            "}"
+        )
+
+    return ''


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

The compile step can pull the config.toml theme values out as root css variables. Users can then more easily style their apps via Streamlits theme

### Summary of Changes

- Add new generate css from theme config function
- Bump package version