### PR TITLE
Fix old readme links to oss org

### DIFF
--- a/PLACEHOLDERS.md
+++ b/PLACEHOLDERS.md
@@ -278,7 +278,7 @@
 %sal-tabs-panel {}        // Targets the content panel div
 
 // %sal-logo has Alternate support as it lies outside the main container.
-// It can be styled directly using %%sal-logo within main.scss but does not allow custom classes
+// It can be styled directly using %sal-logo within main.scss but does not allow custom classes
 
 /*** Chat elements ***/
 %sal-chat-input {}            // Targets the stChatInput div child element

--- a/PLACEHOLDERS.md
+++ b/PLACEHOLDERS.md
@@ -277,7 +277,7 @@
 %sal-tabs-list-buttons {} // Targets the button elements with the tab list
 %sal-tabs-panel {}        // Targets the content panel div
 
-// %sal-logo has Alternate support as it lies outside the main container.
+// %sal-logo has alternate support as it lies outside the main container.
 // It can be styled directly using %sal-logo within main.scss but does not allow custom classes
 
 /*** Chat elements ***/

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This will render a streamlit markdown element with a style tag containing the co
 ### Add placeholders, compile and render
 
 Navigate to your `main.scss` and start adding the style placeholders that you need. The available predefined
-placeholders can be found [here](https://github.com/datarobot/streamlit-sal/PLACEHOLDERS.md). A rule of thumb for
+placeholders can be found [here](https://github.com/datarobot-oss/streamlit-sal/PLACEHOLDERS.md). A rule of thumb for
 placeholders is that every Streamlit component name
 exists with a `sal-` prefix and underscores are replaced by dashes (`st.download_button` -> `sal-download-button`)
 
@@ -226,7 +226,7 @@ div:has(> div.stMarkdown > div[data-testid="stMarkdownContainer"] span.sal-butto
 ### Building the selectors so you don't have to
 
 SAL uses SASS to dynamically build all the required selectors using
-a [component structure map](https://github.com/datarobot/streamlit-sal/blob/main/streamlit_sal/sass/_streamlit-component-map.scss)
+a [component structure map](https://github.com/datarobot-oss/streamlit-sal/blob/main/streamlit_sal/sass/_streamlit-component-map.scss)
 and an `@each` loop.
 The output CSS will be selectors just like the one seen above. All the defined SASS `%` placeholders are optional and
 will not be part of the compiled when not set.

--- a/streamlit_sal/components.py
+++ b/streamlit_sal/components.py
@@ -4,7 +4,7 @@ from .utils import create_markdown_container
 def validate_container_kwarg(component_name, **kwargs):
     if 'container' not in kwargs:
         print(
-            f"[INFO] Pass the layout container from your st.{component_name} call to SAL. Read more here: https://github.com/datarobot/streamlit-sal/blob/main/README.md")
+            f"[INFO] Pass the layout container from your st.{component_name} call to SAL. Read more here: https://github.com/datarobot-oss/streamlit-sal/blob/main/README.md")
         raise TypeError(f"(sal.{component_name}) Missing required keyword argument: 'container'")
     pass
 


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

### Summary of Changes

- Change links from /datarobot/ to /datarobot-oss/